### PR TITLE
fix: make error message more precise

### DIFF
--- a/main/kgcpsecret.go
+++ b/main/kgcpsecret.go
@@ -231,7 +231,7 @@ func getBestFittingSecretValue(ctx context.Context, client *secretmanager.Client
 			}
 		}
 	}
-	return "", fmt.Errorf("couldn't find value for secret '%s'", key)
+	return "", fmt.Errorf("couldn't find value for secret '%s' in Google project '%s'", key, plugin.GCPProjectID)
 }
 
 func listGCPSecrets(projectID string) ([]string, error) {

--- a/main/kgcpsecret_base_test.go
+++ b/main/kgcpsecret_base_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+//go:build unitTests
 // +build unitTests
 
 package main_test
@@ -118,9 +119,12 @@ var _ = Describe("when creating a Kubernetes secret from an KGCPSecret with non 
 	}
 
 	It("should create an error", func() {
+		expected := "couldn't find value for secret 'do-not-exist' in Google project 'cf-2tier-uhd-test-d7'"
+
 		_, err := GetSecrets(ctx, nil, &encryptedSecret, getBaseTestKeys, getBaseTestValue)
 
 		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(expected))
 	})
 })
 


### PR DESCRIPTION
When working with more than one Google Secret Manager
it is helpful to know, in which project the search for a secret
was failing (#7).