### PR TITLE
feat: Replace keys 'stage' and 'dc'

### DIFF
--- a/.github/workflows/journey-test.yaml
+++ b/.github/workflows/journey-test.yaml
@@ -13,11 +13,11 @@ jobs:
       - name: Setup tools used by WaaS
         uses: metro-digital/setup-tools-for-waas@v0.x
         with:
-          version: 'waas/v1alpha4'
+          version: 'waas/v2alpha1'
           gcp_sa_key: '${{ secrets.GCP_SA_KEY }}'
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       - name: Build kustomize plugin and install it
         run: |
           export XDG_CONFIG_HOME=${XDG_CONFIG_HOME-${HOME}/.config}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # kustomize-google-secret-manager
 
-A Kustomize Plugin to create Kubernetes Secrets out of Google Secret Manager.
+A Kustomize Plugin to create Kubernetes Secrets populated with values from Google Secret Manager.
 
 Each Kubernetes secret object is represented by one object of kind `KGCPSecret`.
-The metadata.name and metadata.namespace of the object will be the name and namespace of
+The `metadata.name` and `metadata.namespace` of the object will be the name and namespace of
 the Kubernetes secret, with a possible suffix hash. The key names are each represented by
 a secret in a Secrets Manager, see below for naming.
 
@@ -27,10 +27,10 @@ Possible prefixes:
 
 Possible postfixes:
 
-* `stage`
-* `dc`
+* `environment` (old `stage` is still supported, but will be overwritten by this one if both exists)
+* `tag` (old `dc` is still supported, but will be overwritten by this one if both exists)
 
-So the most specific entry for key `password` in Secret Manager is `<namespace>_<name>_password_<stage>_<dc>` e.g. `bdm-ns_db-secrets_password_prod_be-gcw1`.
+So the most specific entry for key `password` in Secret Manager is `<namespace>_<name>_password_<environment>_<tag>` e.g. `bdm-ns_db-secrets_password_prod_be-gcw1`.
 And the most generic one is `password`.
 
 ## Authentication to Google Secrets Manager

--- a/journey-test/journey-test.sh
+++ b/journey-test/journey-test.sh
@@ -6,6 +6,6 @@ testdirs=$(find . -name 'test*' -type d )
 
 for t in $testdirs; do
     echo "running test in $t"
-    kustomize build --enable_alpha_plugins "$t" > "$t"/output.yaml
+    kustomize build --enable-alpha-plugins "$t" > "$t"/output.yaml
     diff "$t"/expected.yaml "$t"/output.yaml
 done

--- a/journey-test/test-pp-be-gcw1-old-keys/expected.yaml
+++ b/journey-test/test-pp-be-gcw1-old-keys/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  CASSANDRA_URL: Y2Fzc2FuZHJhLXBwLmJlLWdjdzEubWV0cm8uZGlnaXRhbA==
+  CDN_URL: aHR0cHM6Ly9ldXJvcGUuY2RuLm5ldA==
+  KUBERNETES_URL: aHR0cHM6Ly9rdWJlcm5ldGVzLXBwLm1ldHJvLmRpZ2l0YWw=
+kind: Secret
+metadata:
+  name: gcp-secret

--- a/journey-test/test-pp-be-gcw1-old-keys/input.yaml
+++ b/journey-test/test-pp-be-gcw1-old-keys/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  environment: prod
-  tag: rc-tcm1
+  stage: pp
+  dc: be-gcw1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-pp-be-gcw1-old-keys/kustomization.yaml
+++ b/journey-test/test-pp-be-gcw1-old-keys/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+- input.yaml

--- a/journey-test/test-pp-be-gcw1/input.yaml
+++ b/journey-test/test-pp-be-gcw1/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  stage: pp
-  dc: be-gcw1
+  environment: pp
+  tag: be-gcw1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-pp-cn-tcs1-old-keys/expected.yaml
+++ b/journey-test/test-pp-cn-tcs1-old-keys/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  CASSANDRA_URL: Y2Fzc2FuZHJhLXBwLmNuLXRjczEubWV0cm8uZGlnaXRhbA==
+  CDN_URL: aHR0cHM6Ly9hc2lhLmNkbi5uZXQ=
+  KUBERNETES_URL: aHR0cHM6Ly9rdWJlcm5ldGVzLXBwLm1ldHJvLmRpZ2l0YWw=
+kind: Secret
+metadata:
+  name: gcp-secret

--- a/journey-test/test-pp-cn-tcs1-old-keys/input.yaml
+++ b/journey-test/test-pp-cn-tcs1-old-keys/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  environment: prod
-  tag: rc-tcm1
+  stage: pp
+  dc: cn-tcs1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-pp-cn-tcs1-old-keys/kustomization.yaml
+++ b/journey-test/test-pp-cn-tcs1-old-keys/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+- input.yaml

--- a/journey-test/test-pp-cn-tcs1/input.yaml
+++ b/journey-test/test-pp-cn-tcs1/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  stage: pp
-  dc: cn-tcs1
+  environment: pp
+  tag: cn-tcs1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-pp-ru-tcm1-old-keys/expected.yaml
+++ b/journey-test/test-pp-ru-tcm1-old-keys/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  CASSANDRA_URL: Y2Fzc2FuZHJhLXBwLmJlLWdjdzEubWV0cm8uZGlnaXRhbA==
+  CDN_URL: aHR0cHM6Ly9ldXJvcGUuY2RuLm5ldA==
+  KUBERNETES_URL: aHR0cHM6Ly9rdWJlcm5ldGVzLXBwLm1ldHJvLmRpZ2l0YWw=
+kind: Secret
+metadata:
+  name: gcp-secret

--- a/journey-test/test-pp-ru-tcm1-old-keys/input.yaml
+++ b/journey-test/test-pp-ru-tcm1-old-keys/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  environment: prod
-  tag: rc-tcm1
+  stage: pp
+  dc: rc-tcm1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-pp-ru-tcm1-old-keys/kustomization.yaml
+++ b/journey-test/test-pp-ru-tcm1-old-keys/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+- input.yaml

--- a/journey-test/test-pp-ru-tcm1/input.yaml
+++ b/journey-test/test-pp-ru-tcm1/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  stage: pp
-  dc: rc-tcm1
+  environment: pp
+  tag: rc-tcm1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-prod-be-gcw1-old-keys/expected.yaml
+++ b/journey-test/test-prod-be-gcw1-old-keys/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  CASSANDRA_URL: Y2Fzc2FuZHJhLXByb2QuYmUtZ2N3MS5tZXRyby5kaWdpdGFs
+  CDN_URL: aHR0cHM6Ly9ldXJvcGUuY2RuLm5ldA==
+  KUBERNETES_URL: aHR0cHM6Ly9rdWJlcm5ldGVzLXByb2QubWV0cm8uZGlnaXRhbA==
+kind: Secret
+metadata:
+  name: gcp-secret

--- a/journey-test/test-prod-be-gcw1-old-keys/input.yaml
+++ b/journey-test/test-prod-be-gcw1-old-keys/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  environment: prod
-  tag: rc-tcm1
+  stage: prod
+  dc: be-gcw1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-prod-be-gcw1-old-keys/kustomization.yaml
+++ b/journey-test/test-prod-be-gcw1-old-keys/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+- input.yaml

--- a/journey-test/test-prod-be-gcw1/input.yaml
+++ b/journey-test/test-prod-be-gcw1/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  stage: prod
-  dc: be-gcw1
+  environment: prod
+  tag: be-gcw1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-prod-cn-tcs1-old-keys/expected.yaml
+++ b/journey-test/test-prod-cn-tcs1-old-keys/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  CASSANDRA_URL: Y2Fzc2FuZHJhLXByb2QuY24tdGNzMS5tZXRyby5kaWdpdGFs
+  CDN_URL: aHR0cHM6Ly9hc2lhLmNkbi5uZXQ=
+  KUBERNETES_URL: aHR0cHM6Ly9rdWJlcm5ldGVzLXByb2QubWV0cm8uZGlnaXRhbA==
+kind: Secret
+metadata:
+  name: gcp-secret

--- a/journey-test/test-prod-cn-tcs1-old-keys/input.yaml
+++ b/journey-test/test-prod-cn-tcs1-old-keys/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  environment: prod
-  tag: rc-tcm1
+  stage: prod
+  dc: cn-tcs1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-prod-cn-tcs1-old-keys/kustomization.yaml
+++ b/journey-test/test-prod-cn-tcs1-old-keys/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+- input.yaml

--- a/journey-test/test-prod-cn-tcs1/input.yaml
+++ b/journey-test/test-prod-cn-tcs1/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  stage: prod
-  dc: cn-tcs1
+  environment: prod
+  tag: cn-tcs1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-prod-ru-tcm1-old-keys/expected.yaml
+++ b/journey-test/test-prod-ru-tcm1-old-keys/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  CASSANDRA_URL: Y2Fzc2FuZHJhLXByb2QuYmUtZ2N3MS5tZXRyby5kaWdpdGFs
+  CDN_URL: aHR0cHM6Ly9ldXJvcGUuY2RuLm5ldA==
+  KUBERNETES_URL: aHR0cHM6Ly9rdWJlcm5ldGVzLXByb2QubWV0cm8uZGlnaXRhbA==
+kind: Secret
+metadata:
+  name: gcp-secret

--- a/journey-test/test-prod-ru-tcm1-old-keys/input.yaml
+++ b/journey-test/test-prod-ru-tcm1-old-keys/input.yaml
@@ -2,8 +2,8 @@ apiVersion: metro.digital/v1
 kind: KGCPSecret
 metadata:
   name: gcp-secret
-  environment: prod
-  tag: rc-tcm1
+  stage: prod
+  dc: rc-tcm1
 gcpProjectID:   metro-cf-2tier-github-mom 
 disableNameSuffixHash: true
 keys:

--- a/journey-test/test-prod-ru-tcm1-old-keys/kustomization.yaml
+++ b/journey-test/test-prod-ru-tcm1-old-keys/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+- input.yaml

--- a/main/kgcpsecret.go
+++ b/main/kgcpsecret.go
@@ -50,6 +50,8 @@ type ObjectMeta struct {
 
 // GCPObjectMeta contains the meta data for KGCPSecret
 type GCPObjectMeta struct {
+	Environment string `json:"environment" yaml:"environment"`
+	Tag         string `json:"tag" yaml:"tag"`
 	Dc          string `json:"dc" yaml:"dc"`
 	Stage       string `json:"stage" yaml:"stage"`
 	Name        string `json:"name" yaml:"name"`
@@ -205,7 +207,14 @@ func getBestFittingSecretValue(ctx context.Context, client *secretmanager.Client
 	plugin *KGCPSecret, allKeys []string, key string, getSecretValues secretValueGetter) (string, error) {
 	var err error
 	value := ""
-
+	environment := plugin.Stage
+	if plugin.Environment != "" {
+		environment = plugin.Environment
+	}
+	tag := plugin.Dc
+	if plugin.Tag != "" {
+		tag = plugin.Tag
+	}
 	prefixes := []string{
 		plugin.Namespace + "_" + plugin.Name + "_",
 		plugin.Name + "_",
@@ -213,9 +222,9 @@ func getBestFittingSecretValue(ctx context.Context, client *secretmanager.Client
 		"",
 	}
 	postfixes := []string{
-		"_" + plugin.Stage + "_" + plugin.Dc,
-		"_" + plugin.Stage,
-		"_" + plugin.Dc,
+		"_" + environment + "_" + tag,
+		"_" + environment,
+		"_" + tag,
 		"",
 	}
 	for _, prefix := range prefixes {

--- a/main/kgcpsecret_postfix_test.go
+++ b/main/kgcpsecret_postfix_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+//go:build unitTests
 // +build unitTests
 
 package main_test
@@ -69,7 +70,6 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 		encryptedSecret := createEncryptedGCPSecret(name, key)
 
 		encryptedSecret.Stage = "pp"
-		encryptedSecret.Dc = "be-gcw1"
 		value := "https://kubernetes-pp.metro.digital"
 		expected := createExpectedK8SSecret(name, key, value)
 		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
@@ -198,5 +198,192 @@ var _ = Describe("when creating a Kubernetes secret with different values for st
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 
+	})
+})
+
+var _ = Describe("when creating a Kubernetes secret with different values for environments", func() {
+
+	It("should use the correspondig environment data value for every secret", func() {
+		name := "my-secret"
+		key := "KUBERNETES_URL"
+		encryptedSecret := createEncryptedGCPSecret(name, key)
+
+		encryptedSecret.Environment = "pp"
+		encryptedSecret.Tag = "be-gcw1"
+		value := "https://kubernetes-pp.metro.digital"
+		expected := createExpectedK8SSecret(name, key, value)
+		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		value = "https://kubernetes-prod.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+})
+
+var _ = Describe("when creating a Kubernetes secret with different values for tags", func() {
+
+	It("should use the correspondig tag data value for every secret", func() {
+		name := "my-secret"
+		key := "CDN_URL"
+		encryptedSecret := createEncryptedGCPSecret(name, key)
+
+		encryptedSecret.Environment = "prod"
+		encryptedSecret.Tag = "be-gcw1"
+		value := "https://europe.cdn.net"
+		expected := createExpectedK8SSecret(name, key, value)
+		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		encryptedSecret.Tag = "nl-gcw4"
+		value = "https://europe.cdn.net"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		encryptedSecret.Tag = "cn-tcs1"
+		value = "https://asia.cdn.net"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		encryptedSecret.Tag = "ru-tcm1"
+		value = "https://russia.cdn.net"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+	})
+})
+
+var _ = Describe("when creating a Kubernetes secret with different values for environments and tags", func() {
+
+	It("should use the most specific data value for every secret", func() {
+		name := "my-secret"
+		key := "CASSANDRA_URL"
+		encryptedSecret := createEncryptedGCPSecret(name, key)
+
+		encryptedSecret.Environment = "pp"
+		encryptedSecret.Tag = "be-gcw1"
+		value := "cassandra-pp.be-gcw1.metro.digital"
+		expected := createExpectedK8SSecret(name, key, value)
+		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		encryptedSecret.Tag = "be-gcw1"
+		value = "cassandra-prod.be-gcw1.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "pp"
+		encryptedSecret.Tag = "nl-gcw4"
+		value = "cassandra-pp.be-gcw1.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		encryptedSecret.Tag = "nl-gcw4"
+		value = "cassandra-prod.be-gcw1.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "pp"
+		encryptedSecret.Tag = "cn-tcs1"
+		value = "cassandra-pp.cn-tcs1.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		encryptedSecret.Tag = "cn-tcs1"
+		value = "cassandra-prod.cn-tcs1.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "pp"
+		encryptedSecret.Tag = "ru-tcm1"
+		value = "cassandra-pp.ru-tcm1.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		encryptedSecret.Tag = "ru-tcm1"
+		value = "cassandra-prod.ru-tcm1.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+	})
+})
+
+var _ = Describe("when creating a Kubernetes secret using environments and stages", func() {
+	It("should use environments and overwrite stages", func() {
+		name := "my-secret"
+		key := "KUBERNETES_URL"
+		encryptedSecret := createEncryptedGCPSecret(name, key)
+		encryptedSecret.Stage = "xx"
+
+		encryptedSecret.Environment = "pp"
+		value := "https://kubernetes-pp.metro.digital"
+		expected := createExpectedK8SSecret(name, key, value)
+		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Environment = "prod"
+		value = "https://kubernetes-prod.metro.digital"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+})
+
+var _ = Describe("when creating a Kubernetes secret using tags and data-centers", func() {
+
+	It("should use tags and overwrite dc", func() {
+		name := "my-secret"
+		key := "CDN_URL"
+		encryptedSecret := createEncryptedGCPSecret(name, key)
+		encryptedSecret.Dc = "xxx"
+
+		encryptedSecret.Tag = "be-gcw1"
+		value := "https://europe.cdn.net"
+		expected := createExpectedK8SSecret(name, key, value)
+		actual, err := GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+
+		encryptedSecret.Tag = "nl-gcw4"
+		value = "https://europe.cdn.net"
+		expected = createExpectedK8SSecret(name, key, value)
+		actual, err = GetSecrets(ctx, nil, &encryptedSecret, getPostfixTestKeys, getPostfixTestValue)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(Equal(expected))
 	})
 })


### PR DESCRIPTION
We don't want to use any longer the old keys 'stage'
and 'dc', because they are related to an outdated
infrastructure model in METRO.digital.

Therefore we introduce the more generic ones:
- environment (overwrites stage)
- tag (overwrites dc)

For compability reasons we will keep to old keys
usable.
Fix #9