### PR TITLE
improve error log when getting a GCP secret value

### DIFF
--- a/main/kgcpsecret.go
+++ b/main/kgcpsecret.go
@@ -204,8 +204,8 @@ func createGCPSecretValuesGetter(plugin *KGCPSecret, listGCPSecrets secretsGette
 }
 
 func getBestFittingSecretValue(ctx context.Context, client *secretmanager.Client,
-	plugin *KGCPSecret, allKeys []string, key string, getSecretValues secretValueGetter) (string, error) {
-	var err error
+	plugin *KGCPSecret, allKeys []string, key string, getSecretValue secretValueGetter) (string, error) {
+	var err = errors.New(fmt.Sprintf("key '%s' was not found", key))
 	value := ""
 	environment := plugin.Stage
 	if plugin.Environment != "" {
@@ -232,7 +232,7 @@ func getBestFittingSecretValue(ctx context.Context, client *secretmanager.Client
 			lookupKey := prefix + key + postfix
 			for _, k := range allKeys {
 				if k == lookupKey {
-					value, err = getSecretValues(ctx, client, plugin, lookupKey)
+					value, err = getSecretValue(ctx, client, plugin, lookupKey)
 					if err == nil && value != "" {
 						return value, nil
 					}
@@ -240,7 +240,7 @@ func getBestFittingSecretValue(ctx context.Context, client *secretmanager.Client
 			}
 		}
 	}
-	return "", fmt.Errorf("couldn't find value for secret '%s' in Google project '%s'", key, plugin.GCPProjectID)
+	return "", fmt.Errorf("error getting '%s' secret in Google project '%s'. %s", key, plugin.GCPProjectID, err)
 }
 
 func listGCPSecrets(projectID string) ([]string, error) {


### PR DESCRIPTION
This PR adds error log from secret manager client library. So, it should be more obvious how to fix the problem.
I faced an error using this plugin. My account had an Editor role I had an access to secrets, but the plugin was returning the same error "couldn't find value for secret 'MY_SECRET_VARIABLE' in Google project 'my-project'". 
The actual error was that I didn't have secretmanager.versions.access permission, which are not granted to Editor role. 